### PR TITLE
make java relation optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ charm needs to do is respond to one or more of the states listed below.
 The plugin services provides the appropriate Hadoop libraries for the cluster,
 and sets up the standard Hadoop config files in `/etc/hadoop/conf`.
 
+
 # Usage
 
 To create a charm layer using this base layer, you need only include it in
 a `layer.yaml` file:
 
-```yaml
-includes: ['layer:hadoop-client']
-```
+    includes: ['layer:hadoop-client']
 
 This will fetch this layer from [interfaces.juju.solutions][] and incorporate
 it into your charm layer.  You can then add handlers under the `reactive/`
@@ -52,14 +51,12 @@ This layer, via the [hadoop-plugin][] interface, will set the following states:
 
 An example using these states would be:
 
-```python
-@when('hadoop.ready')
-def configure_service(hadoop):
-    update_config(
-        hadoop.namenodes(), hadoop.hdfs_port(),
-        hadoop.resourcemanagers(), hadoop.yarn_port())
-    restart_service()
-```
+    @when('hadoop.ready')
+    def configure_service(hadoop):
+        update_config(
+            hadoop.namenodes(), hadoop.hdfs_port(),
+            hadoop.resourcemanagers(), hadoop.yarn_port())
+        restart_service()
 
 
 # Layer Configuration
@@ -85,25 +82,22 @@ This layer supports the following options, which can be set in `layer.yaml`:
 
 An example `layer.yaml` using these options might be:
 
-```yaml
-includes: ['layer:hadoop-client']
-options:
-  hadoop-client:
-    groups: [spark]
-    users: [spark]
-    dirs:
-      spark_home:
-        path: /var/lib/spark
-        perms: 0755
-        owner: spark
-        group: spark
-```
+    includes: ['layer:hadoop-client']
+    options:
+      hadoop-client:
+        groups: [spark]
+        users: [spark]
+        dirs:
+          spark_home:
+            path: /var/lib/spark
+            perms: 0755
+            owner: spark
+            group: spark
 
 
-# Actions
+# Contact Information
 
-This layer currently does not define any actions.
-
+- <bigdata@lists.ubuntu.com>
 
 [hadoop-core]: https://jujucharms.com/hadoop-processing/
 [building]: https://jujucharms.com/docs/devel/authors-charm-building

--- a/layer.yaml
+++ b/layer.yaml
@@ -68,6 +68,10 @@ defines:
   silent:
     description: >
       When set to true this layer will not change the status messages of the
-      charm. State are not affected.
+      charm. States are not affected.
+
+      DEPRECATED: This layer now only reports status when deployed as the
+      'hadoop-client' charm. This 'silent' option has no effect on status
+      messages in this layer.
     type: boolean
     default: false

--- a/reactive/hadoop_client.py
+++ b/reactive/hadoop_client.py
@@ -1,37 +1,27 @@
 # pylint: disable=unused-argument
 from charms.reactive import when, when_not
 from charmhelpers.core import hookenv
-from charms import layer
 
 
 if hookenv.metadata()['name'] == 'hadoop-client':
-    # only report Ready status if deployed as standalone client,
+    # only report status if deployed as standalone client,
     # not if used as a base layer
     @when('hadoop.installed')
     def report_ready(hadoop):
         hookenv.status_set('active', 'ready')
 
-
-@when_not('hadoop.joined')
-def report_blocked():
-    cfg = layer.options('hadoop-client')
-    if not cfg.get('silent'):
+    @when_not('hadoop.joined')
+    def report_blocked():
         hookenv.status_set('blocked', 'waiting for relation to hadoop plugin')
 
-
-@when('hadoop.joined')
-@when_not('hadoop.installed')
-def report_waiting_for_hadoop(hadoop):
-    cfg = layer.options('hadoop-client')
-    if not cfg.get('silent'):
+    @when('hadoop.joined')
+    @when_not('hadoop.installed')
+    def report_waiting_for_hadoop(hadoop):
         hookenv.status_set('waiting', 'waiting for plugin to become ready')
 
-
-@when('java.connected')
-@when_not('java.ready')
-def report_waiting_for_java(hadoop):
-    cfg = layer.options('hadoop-client')
-    if not cfg.get('silent'):
+    @when('java.connected')
+    @when_not('java.ready')
+    def report_waiting_for_java(hadoop):
         hookenv.status_set('waiting', 'waiting for java to become ready')
 
 

--- a/tests/01-basic-deployment.py
+++ b/tests/01-basic-deployment.py
@@ -13,7 +13,7 @@ class TestDeploy(unittest.TestCase):
     """
 
     def test_deploy(self):
-        self.d = amulet.Deployment(series='trusty')
+        self.d = amulet.Deployment(series='xenial')
         self.d.add('client', 'hadoop-client')
         self.d.setup(timeout=900)
         self.d.sentry.wait(timeout=1800)


### PR DESCRIPTION
Don't report blocked on a java relationship.  This should only affect the standalone hadoop-client charm, since the status updates are guarded with `if not silent`.

While I'm here, cleanup the readme for charmstore formatting and update the simple deployment test for xenial.
